### PR TITLE
fix: array 的子项为 object 时无法设置子项必选

### DIFF
--- a/src/JsonSchemaEditor/SchemaItem/index.tsx
+++ b/src/JsonSchemaEditor/SchemaItem/index.tsx
@@ -32,7 +32,6 @@ import {
 type SchemaItemProps = {
   propertyName?: string;
   nodeDepth?: number;
-  parentSchemaDepth?: number;
   namePath?: number[];
   isArrayItems?: boolean;
   isRequire?: boolean;
@@ -45,11 +44,7 @@ type SchemaItemProps = {
   renameProperty?: (namePath: number[], name: string) => void;
   removeProperty?: (namePath: number[]) => void;
   addProperty?: (path: number[], isChild: boolean) => void;
-  updateRequiredProperty?: (
-    path: number[],
-    requiredProperty: string,
-    removed: boolean,
-  ) => void;
+  updateRequiredProperty?: (namePath: number[], removed: boolean) => void;
   handleAdvancedSettingClick?: (
     namePath: number[],
     schema: JSONSchema7,
@@ -65,7 +60,6 @@ function SchemaItem(props: SchemaItemProps) {
     renameProperty,
     isArrayItems,
     updateRequiredProperty,
-    parentSchemaDepth = 0,
     removeProperty,
     addProperty,
     isRequire,
@@ -182,11 +176,7 @@ function SchemaItem(props: SchemaItemProps) {
             checked={isRequire}
             onChange={(e) => {
               if (updateRequiredProperty && propertyName) {
-                updateRequiredProperty(
-                  namePath.slice(0, parentSchemaDepth),
-                  propertyName,
-                  !e.target.checked,
-                );
+                updateRequiredProperty(namePath, !e.target.checked);
               }
             }}
           />
@@ -358,7 +348,6 @@ function SchemaItem(props: SchemaItemProps) {
                   isRequire={schema.required?.includes(name)}
                   isArrayItems={false}
                   nodeDepth={nodeDepth + 1}
-                  parentSchemaDepth={!isRoot ? parentSchemaDepth + 2 : 0}
                   namePath={namePath.concat(
                     getPropertyIndex(schema, 'properties'),
                     getPropertyIndex(schema.properties, name),
@@ -378,7 +367,6 @@ function SchemaItem(props: SchemaItemProps) {
           isRequire={false}
           isArrayItems={true}
           nodeDepth={nodeDepth + 1}
-          parentSchemaDepth={!isRoot ? parentSchemaDepth + 1 : 0}
           propertyName={'items'}
           namePath={namePath.concat(getPropertyIndex(schema, 'items'))}
           schema={schema.items as JSONSchema7}

--- a/src/JsonSchemaEditor/utils.ts
+++ b/src/JsonSchemaEditor/utils.ts
@@ -180,6 +180,22 @@ export function getPropertyIndex(obj: any, propName: string): number {
   return keys.indexOf(propName);
 }
 
+export function getValueByPath(obj: any, path: number[]): any {
+  if (path.length === 0) {
+    return obj;
+  }
+  let current = obj;
+  for (let i = 0; i < path.length; i++) {
+    const key = Object.keys(current)[path[i]];
+    if (key === undefined) {
+      return undefined;
+    } else {
+      current = current[key];
+    }
+  }
+  return current;
+}
+
 export const StringFormat = [
   { value: 'date-time' },
   { value: 'date' },


### PR DESCRIPTION
Hi，我最近在工作中 fork 并使用了这个项目，感谢作者的维护工作。今天我也遇到了 https://github.com/lin-mt/json-schema-editor-antd/issues/21 中提到的必选项无法设置的问题，自己修复了一下。

原本的代码里使用 `parentSchemaDepth` 属性来追踪当前层级的方式个人感觉可以直接使用 `namePath` + `getValueByPath` 的方式来代替，代码的可读性也更强一些（调代码的时候这个 `parentSchemaDepth` 行为确实让我有些困惑）。这个 PR 更改了 `updateRequiredProperty` 的逻辑，也解决了上文中提到的 issue 所描述的问题。